### PR TITLE
Add computed expressions and alignment tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/mdql-db/mdql"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A database where every entry is a markdown file and every change is a readable diff.
 
-MDQL turns folders of markdown files into a schema-validated, queryable database. Frontmatter fields are metadata columns. H2 sections are content columns. The files are the database — there is nothing else. Every file reads like a normal markdown document, but you get full SQL: SELECT, INSERT, UPDATE, DELETE, JOINs across multiple tables, ORDER BY, and aggregation.
+MDQL turns folders of markdown files into a schema-validated, queryable database. Frontmatter fields are metadata columns. H2 sections are content columns. The files are the database — there is nothing else. Every file reads like a normal markdown document, but you get full SQL: SELECT, INSERT, UPDATE, DELETE, JOINs across multiple tables, ORDER BY, aggregation, computed expressions, and CASE WHEN.
 
 Your database lives in git. Every insert, update, and migration is a readable diff. Branching, merging, and rollback come free.
 
@@ -225,6 +225,19 @@ rows, columns = strategies.query(
 )
 # rows: list of dicts
 # columns: list of column names
+
+# Computed expressions and CASE WHEN
+rows, columns = strategies.query(
+    "SELECT title, mechanism * safety score, "
+    "CASE WHEN mechanism >= 7 THEN 'high' ELSE 'low' END tier "
+    "FROM strategies ORDER BY score DESC"
+)
+
+# Conditional aggregation
+rows, columns = strategies.query(
+    "SELECT SUM(CASE WHEN status = 'LIVE' THEN 1 ELSE 0 END) live_count, "
+    "COUNT(*) total FROM strategies"
+)
 ```
 
 ### Load rows with filtering
@@ -353,6 +366,54 @@ mdql query examples/strategies/ \
 Supported WHERE operators: `=`, `!=`, `<`, `>`, `<=`, `>=`, `LIKE`, `IN`, `IS NULL`, `IS NOT NULL`, `AND`, `OR`
 
 Column names with spaces use backticks: `` SELECT `Structural Mechanism` FROM strategies ``
+
+### Computed expressions
+
+Arithmetic expressions (`+`, `-`, `*`, `/`, `%`) work in SELECT, WHERE, and ORDER BY. Supports parentheses, unary minus, and mixed int/float coercion.
+
+```bash
+# Computed columns with aliases
+mdql query examples/strategies/ \
+  "SELECT title, mechanism * safety total_score FROM strategies ORDER BY total_score DESC LIMIT 5"
+
+# Expressions in WHERE
+mdql query examples/strategies/ \
+  "SELECT title FROM strategies WHERE mechanism + implementation > 10"
+
+# Parenthesized expressions
+mdql query examples/strategies/ \
+  "SELECT title, (mechanism + implementation) / 2 avg_score FROM strategies"
+```
+
+Integer division truncates (`7 / 2 = 3`). Division by zero returns NULL. NULL propagates through all arithmetic.
+
+### Column aliases
+
+Columns can be aliased with `AS` or by placing the alias directly after the expression (implicit alias). ORDER BY can reference SELECT aliases.
+
+```bash
+# Explicit alias with AS
+mdql query examples/ \
+  "SELECT s.title AS name, b.sharpe AS ratio FROM strategies s JOIN backtests b ON b.strategy = s.path"
+
+# Implicit alias (no AS keyword)
+mdql query examples/ \
+  "SELECT s.composite comp, b.edge_vs_random edge FROM strategies s JOIN backtests b ON b.strategy = s.path ORDER BY edge DESC"
+```
+
+### CASE WHEN
+
+CASE WHEN expressions work anywhere a value is expected — in SELECT, WHERE, ORDER BY, and inside aggregate functions.
+
+```bash
+# Categorize rows
+mdql query examples/strategies/ \
+  "SELECT title, CASE WHEN mechanism >= 7 THEN 'high' WHEN mechanism >= 4 THEN 'medium' ELSE 'low' END rating FROM strategies"
+
+# Conditional aggregation
+mdql query examples/strategies/ \
+  "SELECT COUNT(*) total, SUM(CASE WHEN mechanism >= 7 THEN 1 ELSE 0 END) high_mechanism FROM strategies"
+```
 
 ### JOINs
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,17 @@ MDQL turns folders of markdown files into a schema-validated, queryable database
 
 Your database lives in git. Every insert, update, and migration is a readable diff. Branching, merging, and rollback come free.
 
+## Install
+
+```bash
+cargo install mdql          # from source via Cargo
+brew install mdql-db/tap/mdql  # macOS / Linux via Homebrew
+pip install mdql             # Python bindings
+```
+
 ## Quick start
 
 ```bash
-cargo install mdql
 mdql validate examples/strategies/
 # All 100 files valid in table 'strategies'
 

--- a/crates/mdql-core/src/query_engine.rs
+++ b/crates/mdql-core/src/query_engine.rs
@@ -154,8 +154,27 @@ fn execute_with_fts(
         result.truncate(limit as usize);
     }
 
-    // Project — strip row dicts to only the requested columns
+    // Project — evaluate expressions and strip to requested columns
     if !matches!(query.columns, ColumnList::All) {
+        let named_exprs = match &query.columns {
+            ColumnList::Named(exprs) => exprs,
+            _ => unreachable!(),
+        };
+
+        // Compute expression columns first, then retain only requested columns
+        let has_expr_cols = named_exprs.iter().any(|e| matches!(e, SelectExpr::Expr { .. }));
+        if has_expr_cols {
+            for row in &mut result {
+                for expr in named_exprs {
+                    if let SelectExpr::Expr { expr: e, alias } = expr {
+                        let name = alias.clone().unwrap_or_else(|| e.display_name());
+                        let val = evaluate_expr(e, row);
+                        row.insert(name, val);
+                    }
+                }
+            }
+        }
+
         let col_set: std::collections::HashSet<&str> =
             columns.iter().map(|s| s.as_str()).collect();
         for row in &mut result {
@@ -233,6 +252,13 @@ fn aggregate_rows(
                         .unwrap_or_else(|| expr.output_name());
                     let val = compute_aggregate(func, arg, group_rows);
                     out.insert(out_name, val);
+                }
+                SelectExpr::Expr { expr: e, alias } => {
+                    let out_name = alias.clone().unwrap_or_else(|| e.display_name());
+                    if let Some(first) = group_rows.first() {
+                        let val = evaluate_expr(e, first);
+                        out.insert(out_name, val);
+                    }
                 }
             }
         }
@@ -547,7 +573,104 @@ pub fn evaluate(clause: &WhereClause, row: &Row) -> bool {
     }
 }
 
+/// Evaluate an Expr against a row, returning a Value.
+pub fn evaluate_expr(expr: &Expr, row: &Row) -> Value {
+    match expr {
+        Expr::Literal(SqlValue::Int(n)) => Value::Int(*n),
+        Expr::Literal(SqlValue::Float(f)) => Value::Float(*f),
+        Expr::Literal(SqlValue::String(s)) => Value::String(s.clone()),
+        Expr::Literal(SqlValue::Null) => Value::Null,
+        Expr::Literal(SqlValue::List(_)) => Value::Null,
+        Expr::Column(name) => row.get(name).cloned().unwrap_or(Value::Null),
+        Expr::UnaryMinus(inner) => {
+            match evaluate_expr(inner, row) {
+                Value::Int(n) => Value::Int(-n),
+                Value::Float(f) => Value::Float(-f),
+                Value::Null => Value::Null,
+                _ => Value::Null, // non-numeric → NULL
+            }
+        }
+        Expr::BinaryOp { left, op, right } => {
+            let lv = evaluate_expr(left, row);
+            let rv = evaluate_expr(right, row);
+
+            // NULL propagation: any NULL operand → NULL
+            if lv.is_null() || rv.is_null() {
+                return Value::Null;
+            }
+
+            // Extract numeric values with int→float coercion
+            match (&lv, &rv) {
+                (Value::Int(a), Value::Int(b)) => {
+                    match op {
+                        ArithOp::Add => Value::Int(a.wrapping_add(*b)),
+                        ArithOp::Sub => Value::Int(a.wrapping_sub(*b)),
+                        ArithOp::Mul => Value::Int(a.wrapping_mul(*b)),
+                        ArithOp::Div => {
+                            if *b == 0 { Value::Null } else { Value::Int(a / b) }
+                        }
+                        ArithOp::Mod => {
+                            if *b == 0 { Value::Null } else { Value::Int(a % b) }
+                        }
+                    }
+                }
+                _ => {
+                    // Coerce to float
+                    let a = match &lv {
+                        Value::Int(n) => *n as f64,
+                        Value::Float(f) => *f,
+                        _ => return Value::Null,
+                    };
+                    let b = match &rv {
+                        Value::Int(n) => *n as f64,
+                        Value::Float(f) => *f,
+                        _ => return Value::Null,
+                    };
+                    match op {
+                        ArithOp::Add => Value::Float(a + b),
+                        ArithOp::Sub => Value::Float(a - b),
+                        ArithOp::Mul => Value::Float(a * b),
+                        ArithOp::Div => {
+                            if b == 0.0 { Value::Null } else { Value::Float(a / b) }
+                        }
+                        ArithOp::Mod => {
+                            if b == 0.0 { Value::Null } else { Value::Float(a % b) }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 fn evaluate_comparison(cmp: &Comparison, row: &Row) -> bool {
+    // If we have expression-based comparison (new path), use it for standard ops
+    if let (Some(left_expr), Some(right_expr)) = (&cmp.left_expr, &cmp.right_expr) {
+        if ["=", "!=", "<", ">", "<=", ">="].contains(&cmp.op.as_str()) {
+            let left_val = evaluate_expr(left_expr, row);
+            let right_val = evaluate_expr(right_expr, row);
+
+            // NULL comparison: always false (except IS NULL handled below)
+            if left_val.is_null() || right_val.is_null() {
+                return false;
+            }
+
+            // Coerce for comparison: if types differ, try int→float
+            let ord = compare_model_values(&left_val, &right_val);
+
+            return match cmp.op.as_str() {
+                "=" => ord == Some(Ordering::Equal),
+                "!=" => ord != Some(Ordering::Equal),
+                "<" => ord == Some(Ordering::Less),
+                ">" => ord == Some(Ordering::Greater),
+                "<=" => matches!(ord, Some(Ordering::Less | Ordering::Equal)),
+                ">=" => matches!(ord, Some(Ordering::Greater | Ordering::Equal)),
+                _ => false,
+            };
+        }
+    }
+
+    // Fall back to legacy column-based comparison for IS NULL, IN, LIKE, etc.
     let actual = row.get(&cmp.column);
 
     if cmp.op == "IS NULL" {
@@ -584,6 +707,15 @@ fn evaluate_comparison(cmp: &Comparison, row: &Row) -> bool {
             }
         }
         _ => false,
+    }
+}
+
+/// Compare two model::Value instances, with int↔float coercion.
+fn compare_model_values(a: &Value, b: &Value) -> Option<Ordering> {
+    match (a, b) {
+        (Value::Int(x), Value::Float(y)) => (*x as f64).partial_cmp(y),
+        (Value::Float(x), Value::Int(y)) => x.partial_cmp(&(*y as f64)),
+        _ => a.partial_cmp(b),
     }
 }
 
@@ -762,16 +894,22 @@ fn try_index_filter(
 fn sort_rows(rows: &mut Vec<Row>, specs: &[OrderSpec]) {
     rows.sort_by(|a, b| {
         for spec in specs {
-            let va = a.get(&spec.column);
-            let vb = b.get(&spec.column);
+            let (va, vb) = if let Some(ref expr) = spec.expr {
+                (evaluate_expr(expr, a), evaluate_expr(expr, b))
+            } else {
+                (
+                    a.get(&spec.column).cloned().unwrap_or(Value::Null),
+                    b.get(&spec.column).cloned().unwrap_or(Value::Null),
+                )
+            };
 
             // NULLs sort last
-            let ordering = match (va, vb) {
-                (None, None) | (Some(Value::Null), Some(Value::Null)) => Ordering::Equal,
-                (None, _) | (Some(Value::Null), _) => Ordering::Greater,
-                (_, None) | (_, Some(Value::Null)) => Ordering::Less,
-                (Some(a_val), Some(b_val)) => {
-                    a_val.partial_cmp(b_val).unwrap_or(Ordering::Equal)
+            let ordering = match (&va, &vb) {
+                (Value::Null, Value::Null) => Ordering::Equal,
+                (Value::Null, _) => Ordering::Greater,
+                (_, Value::Null) => Ordering::Less,
+                (a_val, b_val) => {
+                    compare_model_values(a_val, b_val).unwrap_or(Ordering::Equal)
                 }
             };
 
@@ -860,6 +998,8 @@ mod tests {
                 column: "count".into(),
                 op: ">".into(),
                 value: Some(SqlValue::Int(5)),
+                left_expr: Some(Expr::Column("count".into())),
+                right_expr: Some(Expr::Literal(SqlValue::Int(5))),
             })),
             group_by: None,
             order_by: None,
@@ -880,6 +1020,7 @@ mod tests {
             group_by: None,
             order_by: Some(vec![OrderSpec {
                 column: "count".into(),
+                expr: Some(Expr::Column("count".into())),
                 descending: true,
             }]),
             limit: None,
@@ -916,6 +1057,8 @@ mod tests {
                 column: "title".into(),
                 op: "LIKE".into(),
                 value: Some(SqlValue::String("%lph%".into())),
+                left_expr: Some(Expr::Column("title".into())),
+                right_expr: None,
             })),
             group_by: None,
             order_by: None,
@@ -940,6 +1083,8 @@ mod tests {
                 column: "optional".into(),
                 op: "IS NULL".into(),
                 value: None,
+                left_expr: Some(Expr::Column("optional".into())),
+                right_expr: None,
             })),
             group_by: None,
             order_by: None,
@@ -948,5 +1093,153 @@ mod tests {
         let (result, _) = execute(&q, &rows, None).unwrap();
         // All rows where optional is NULL or missing
         assert_eq!(result.len(), 3);
+    }
+
+    // ── Expression evaluation tests ─────────────────────────��─────
+
+    #[test]
+    fn test_evaluate_expr_literal() {
+        let row = Row::new();
+        assert_eq!(evaluate_expr(&Expr::Literal(SqlValue::Int(42)), &row), Value::Int(42));
+        assert_eq!(evaluate_expr(&Expr::Literal(SqlValue::Float(3.14)), &row), Value::Float(3.14));
+        assert_eq!(evaluate_expr(&Expr::Literal(SqlValue::Null), &row), Value::Null);
+    }
+
+    #[test]
+    fn test_evaluate_expr_column() {
+        let row = Row::from([("x".into(), Value::Int(10))]);
+        assert_eq!(evaluate_expr(&Expr::Column("x".into()), &row), Value::Int(10));
+        assert_eq!(evaluate_expr(&Expr::Column("missing".into()), &row), Value::Null);
+    }
+
+    #[test]
+    fn test_evaluate_expr_int_arithmetic() {
+        let row = Row::from([("a".into(), Value::Int(10)), ("b".into(), Value::Int(3))]);
+        let add = Expr::BinaryOp {
+            left: Box::new(Expr::Column("a".into())),
+            op: ArithOp::Add,
+            right: Box::new(Expr::Column("b".into())),
+        };
+        assert_eq!(evaluate_expr(&add, &row), Value::Int(13));
+
+        let sub = Expr::BinaryOp {
+            left: Box::new(Expr::Column("a".into())),
+            op: ArithOp::Sub,
+            right: Box::new(Expr::Column("b".into())),
+        };
+        assert_eq!(evaluate_expr(&sub, &row), Value::Int(7));
+
+        let mul = Expr::BinaryOp {
+            left: Box::new(Expr::Column("a".into())),
+            op: ArithOp::Mul,
+            right: Box::new(Expr::Column("b".into())),
+        };
+        assert_eq!(evaluate_expr(&mul, &row), Value::Int(30));
+
+        let div = Expr::BinaryOp {
+            left: Box::new(Expr::Column("a".into())),
+            op: ArithOp::Div,
+            right: Box::new(Expr::Column("b".into())),
+        };
+        assert_eq!(evaluate_expr(&div, &row), Value::Int(3)); // integer division
+
+        let modulo = Expr::BinaryOp {
+            left: Box::new(Expr::Column("a".into())),
+            op: ArithOp::Mod,
+            right: Box::new(Expr::Column("b".into())),
+        };
+        assert_eq!(evaluate_expr(&modulo, &row), Value::Int(1));
+    }
+
+    #[test]
+    fn test_evaluate_expr_float_coercion() {
+        let row = Row::from([("a".into(), Value::Int(10)), ("b".into(), Value::Float(3.0))]);
+        let add = Expr::BinaryOp {
+            left: Box::new(Expr::Column("a".into())),
+            op: ArithOp::Add,
+            right: Box::new(Expr::Column("b".into())),
+        };
+        assert_eq!(evaluate_expr(&add, &row), Value::Float(13.0));
+    }
+
+    #[test]
+    fn test_evaluate_expr_null_propagation() {
+        let row = Row::from([("a".into(), Value::Int(10))]);
+        let add = Expr::BinaryOp {
+            left: Box::new(Expr::Column("a".into())),
+            op: ArithOp::Add,
+            right: Box::new(Expr::Column("missing".into())),
+        };
+        assert_eq!(evaluate_expr(&add, &row), Value::Null);
+    }
+
+    #[test]
+    fn test_evaluate_expr_div_by_zero() {
+        let row = Row::from([("a".into(), Value::Int(10)), ("b".into(), Value::Int(0))]);
+        let div = Expr::BinaryOp {
+            left: Box::new(Expr::Column("a".into())),
+            op: ArithOp::Div,
+            right: Box::new(Expr::Column("b".into())),
+        };
+        assert_eq!(evaluate_expr(&div, &row), Value::Null);
+    }
+
+    #[test]
+    fn test_evaluate_expr_unary_minus() {
+        let row = Row::from([("x".into(), Value::Int(5))]);
+        let neg = Expr::UnaryMinus(Box::new(Expr::Column("x".into())));
+        assert_eq!(evaluate_expr(&neg, &row), Value::Int(-5));
+    }
+
+    #[test]
+    fn test_select_with_expression() {
+        // Integration test: SELECT count * 2 AS doubled FROM test
+        let stmt = crate::query_parser::parse_query(
+            "SELECT count * 2 AS doubled FROM test"
+        ).unwrap();
+        if let crate::query_parser::Statement::Select(q) = stmt {
+            let (rows, cols) = execute(&q, &make_rows(), None).unwrap();
+            assert_eq!(cols, vec!["doubled"]);
+            assert_eq!(rows.len(), 3);
+            // Rows are: count=10, count=5, count=20
+            let values: Vec<Value> = rows.iter().map(|r| r["doubled"].clone()).collect();
+            assert!(values.contains(&Value::Int(20)));
+            assert!(values.contains(&Value::Int(10)));
+            assert!(values.contains(&Value::Int(40)));
+        } else {
+            panic!("Expected Select");
+        }
+    }
+
+    #[test]
+    fn test_where_with_expression() {
+        // SELECT * FROM test WHERE count * 2 > 15
+        let stmt = crate::query_parser::parse_query(
+            "SELECT * FROM test WHERE count * 2 > 15"
+        ).unwrap();
+        if let crate::query_parser::Statement::Select(q) = stmt {
+            let (rows, _) = execute(&q, &make_rows(), None).unwrap();
+            // count=10 → 20 > 15 ✓, count=5 → 10 > 15 ✗, count=20 → 40 > 15 ✓
+            assert_eq!(rows.len(), 2);
+        } else {
+            panic!("Expected Select");
+        }
+    }
+
+    #[test]
+    fn test_order_by_expression() {
+        // SELECT * FROM test ORDER BY count * -1 ASC (effectively DESC by count)
+        let stmt = crate::query_parser::parse_query(
+            "SELECT title, count FROM test ORDER BY count * -1 ASC"
+        ).unwrap();
+        if let crate::query_parser::Statement::Select(q) = stmt {
+            let (rows, _) = execute(&q, &make_rows(), None).unwrap();
+            // count: 20 → -20, 10 → -10, 5 → -5, ASC means -20, -10, -5
+            assert_eq!(rows[0]["count"], Value::Int(20));
+            assert_eq!(rows[1]["count"], Value::Int(10));
+            assert_eq!(rows[2]["count"], Value::Int(5));
+        } else {
+            panic!("Expected Select");
+        }
     }
 }

--- a/crates/mdql-core/src/query_engine.rs
+++ b/crates/mdql-core/src/query_engine.rs
@@ -144,9 +144,10 @@ fn execute_with_fts(
         filtered
     };
 
-    // Sort
+    // Sort — resolve ORDER BY aliases against SELECT list
     if let Some(ref order_by) = query.order_by {
-        sort_rows(&mut result, order_by);
+        let resolved = resolve_order_aliases(order_by, &query.columns);
+        sort_rows(&mut result, &resolved);
     }
 
     // Limit
@@ -889,6 +890,40 @@ fn try_index_filter(
             }
         }
     }
+}
+
+/// If an ORDER BY column matches a SELECT alias, replace its expr with the
+/// aliased expression so sorting uses the computed value.
+fn resolve_order_aliases(specs: &[OrderSpec], columns: &ColumnList) -> Vec<OrderSpec> {
+    let named = match columns {
+        ColumnList::Named(exprs) => exprs,
+        _ => return specs.to_vec(),
+    };
+
+    // Build alias → expr map
+    let alias_map: HashMap<String, &Expr> = named
+        .iter()
+        .filter_map(|se| match se {
+            SelectExpr::Expr { expr, alias: Some(a) } => Some((a.clone(), expr)),
+            _ => None,
+        })
+        .collect();
+
+    specs
+        .iter()
+        .map(|spec| {
+            // If the ORDER BY column name matches a SELECT alias, use that expression
+            if let Some(expr) = alias_map.get(&spec.column) {
+                OrderSpec {
+                    column: spec.column.clone(),
+                    expr: Some((*expr).clone()),
+                    descending: spec.descending,
+                }
+            } else {
+                spec.clone()
+            }
+        })
+        .collect()
 }
 
 fn sort_rows(rows: &mut Vec<Row>, specs: &[OrderSpec]) {

--- a/crates/mdql-core/src/query_engine.rs
+++ b/crates/mdql-core/src/query_engine.rs
@@ -247,11 +247,11 @@ fn aggregate_rows(
                         }
                     }
                 }
-                SelectExpr::Aggregate { func, arg, alias } => {
+                SelectExpr::Aggregate { func, arg, arg_expr, alias } => {
                     let out_name = alias
                         .clone()
                         .unwrap_or_else(|| expr.output_name());
-                    let val = compute_aggregate(func, arg, group_rows);
+                    let val = compute_aggregate(func, arg, arg_expr.as_ref(), group_rows);
                     out.insert(out_name, val);
                 }
                 SelectExpr::Expr { expr: e, alias } => {
@@ -270,17 +270,27 @@ fn aggregate_rows(
     Ok(result)
 }
 
-fn compute_aggregate(func: &AggFunc, arg: &str, rows: &[&Row]) -> Value {
+/// Resolve a per-row value for an aggregate argument.
+/// If `arg_expr` is set, evaluate it; otherwise look up `arg` as a column name.
+fn resolve_agg_value<'a>(arg: &str, arg_expr: Option<&Expr>, row: &'a Row) -> Value {
+    if let Some(expr) = arg_expr {
+        evaluate_expr(expr, row)
+    } else {
+        row.get(arg).cloned().unwrap_or(Value::Null)
+    }
+}
+
+fn compute_aggregate(func: &AggFunc, arg: &str, arg_expr: Option<&Expr>, rows: &[&Row]) -> Value {
     match func {
         AggFunc::Count => {
-            if arg == "*" {
+            if arg == "*" && arg_expr.is_none() {
                 Value::Int(rows.len() as i64)
             } else {
                 let count = rows
                     .iter()
                     .filter(|r| {
-                        r.get(arg)
-                            .map_or(false, |v| !v.is_null())
+                        let v = resolve_agg_value(arg, arg_expr, r);
+                        !v.is_null()
                     })
                     .count();
                 Value::Int(count as i64)
@@ -290,12 +300,11 @@ fn compute_aggregate(func: &AggFunc, arg: &str, rows: &[&Row]) -> Value {
             let mut total = 0.0f64;
             let mut has_any = false;
             for r in rows {
-                if let Some(v) = r.get(arg) {
-                    match v {
-                        Value::Int(n) => { total += *n as f64; has_any = true; }
-                        Value::Float(f) => { total += f; has_any = true; }
-                        _ => {}
-                    }
+                let v = resolve_agg_value(arg, arg_expr, r);
+                match v {
+                    Value::Int(n) => { total += n as f64; has_any = true; }
+                    Value::Float(f) => { total += f; has_any = true; }
+                    _ => {}
                 }
             }
             if has_any { Value::Float(total) } else { Value::Null }
@@ -304,12 +313,11 @@ fn compute_aggregate(func: &AggFunc, arg: &str, rows: &[&Row]) -> Value {
             let mut total = 0.0f64;
             let mut count = 0usize;
             for r in rows {
-                if let Some(v) = r.get(arg) {
-                    match v {
-                        Value::Int(n) => { total += *n as f64; count += 1; }
-                        Value::Float(f) => { total += f; count += 1; }
-                        _ => {}
-                    }
+                let v = resolve_agg_value(arg, arg_expr, r);
+                match v {
+                    Value::Int(n) => { total += n as f64; count += 1; }
+                    Value::Float(f) => { total += f; count += 1; }
+                    _ => {}
                 }
             }
             if count > 0 { Value::Float(total / count as f64) } else { Value::Null }
@@ -317,38 +325,36 @@ fn compute_aggregate(func: &AggFunc, arg: &str, rows: &[&Row]) -> Value {
         AggFunc::Min => {
             let mut min_val: Option<Value> = None;
             for r in rows {
-                if let Some(v) = r.get(arg) {
-                    if v.is_null() { continue; }
-                    min_val = Some(match min_val {
-                        None => v.clone(),
-                        Some(ref current) => {
-                            if v.partial_cmp(current) == Some(std::cmp::Ordering::Less) {
-                                v.clone()
-                            } else {
-                                current.clone()
-                            }
+                let v = resolve_agg_value(arg, arg_expr, r);
+                if v.is_null() { continue; }
+                min_val = Some(match min_val {
+                    None => v,
+                    Some(ref current) => {
+                        if v.partial_cmp(current) == Some(std::cmp::Ordering::Less) {
+                            v
+                        } else {
+                            current.clone()
                         }
-                    });
-                }
+                    }
+                });
             }
             min_val.unwrap_or(Value::Null)
         }
         AggFunc::Max => {
             let mut max_val: Option<Value> = None;
             for r in rows {
-                if let Some(v) = r.get(arg) {
-                    if v.is_null() { continue; }
-                    max_val = Some(match max_val {
-                        None => v.clone(),
-                        Some(ref current) => {
-                            if v.partial_cmp(current) == Some(std::cmp::Ordering::Greater) {
-                                v.clone()
-                            } else {
-                                current.clone()
-                            }
+                let v = resolve_agg_value(arg, arg_expr, r);
+                if v.is_null() { continue; }
+                max_val = Some(match max_val {
+                    None => v,
+                    Some(ref current) => {
+                        if v.partial_cmp(current) == Some(std::cmp::Ordering::Greater) {
+                            v
+                        } else {
+                            current.clone()
                         }
-                    });
-                }
+                    }
+                });
             }
             max_val.unwrap_or(Value::Null)
         }
@@ -639,6 +645,17 @@ pub fn evaluate_expr(expr: &Expr, row: &Row) -> Value {
                         }
                     }
                 }
+            }
+        }
+        Expr::Case { whens, else_expr } => {
+            for (condition, result) in whens {
+                if evaluate(condition, row) {
+                    return evaluate_expr(result, row);
+                }
+            }
+            match else_expr {
+                Some(e) => evaluate_expr(e, row),
+                None => Value::Null,
             }
         }
     }
@@ -1273,6 +1290,98 @@ mod tests {
             assert_eq!(rows[0]["count"], Value::Int(20));
             assert_eq!(rows[1]["count"], Value::Int(10));
             assert_eq!(rows[2]["count"], Value::Int(5));
+        } else {
+            panic!("Expected Select");
+        }
+    }
+
+    // ── CASE WHEN evaluation tests ────────────────────────────────
+
+    #[test]
+    fn test_case_when_eval_basic() {
+        let row = Row::from([("status".into(), Value::String("ACTIVE".into()))]);
+        let expr = Expr::Case {
+            whens: vec![(
+                WhereClause::Comparison(Comparison {
+                    column: "status".into(),
+                    op: "=".into(),
+                    value: Some(SqlValue::String("ACTIVE".into())),
+                    left_expr: Some(Expr::Column("status".into())),
+                    right_expr: Some(Expr::Literal(SqlValue::String("ACTIVE".into()))),
+                }),
+                Box::new(Expr::Literal(SqlValue::Int(1))),
+            )],
+            else_expr: Some(Box::new(Expr::Literal(SqlValue::Int(0)))),
+        };
+        assert_eq!(evaluate_expr(&expr, &row), Value::Int(1));
+    }
+
+    #[test]
+    fn test_case_when_eval_else() {
+        let row = Row::from([("status".into(), Value::String("KILLED".into()))]);
+        let expr = Expr::Case {
+            whens: vec![(
+                WhereClause::Comparison(Comparison {
+                    column: "status".into(),
+                    op: "=".into(),
+                    value: Some(SqlValue::String("ACTIVE".into())),
+                    left_expr: Some(Expr::Column("status".into())),
+                    right_expr: Some(Expr::Literal(SqlValue::String("ACTIVE".into()))),
+                }),
+                Box::new(Expr::Literal(SqlValue::Int(1))),
+            )],
+            else_expr: Some(Box::new(Expr::Literal(SqlValue::Int(0)))),
+        };
+        assert_eq!(evaluate_expr(&expr, &row), Value::Int(0));
+    }
+
+    #[test]
+    fn test_case_when_eval_no_else_null() {
+        let row = Row::from([("x".into(), Value::Int(99))]);
+        let expr = Expr::Case {
+            whens: vec![(
+                WhereClause::Comparison(Comparison {
+                    column: "x".into(),
+                    op: "=".into(),
+                    value: Some(SqlValue::Int(1)),
+                    left_expr: Some(Expr::Column("x".into())),
+                    right_expr: Some(Expr::Literal(SqlValue::Int(1))),
+                }),
+                Box::new(Expr::Literal(SqlValue::String("one".into()))),
+            )],
+            else_expr: None,
+        };
+        assert_eq!(evaluate_expr(&expr, &row), Value::Null);
+    }
+
+    #[test]
+    fn test_case_when_in_aggregate_query() {
+        // SUM(CASE WHEN count > 5 THEN count ELSE 0 END)
+        // Rows: count=10, count=5, count=20 → should sum 10 + 0 + 20 = 30
+        let stmt = crate::query_parser::parse_query(
+            "SELECT SUM(CASE WHEN count > 5 THEN count ELSE 0 END) AS total FROM test"
+        ).unwrap();
+        if let crate::query_parser::Statement::Select(q) = stmt {
+            let (rows, cols) = execute(&q, &make_rows(), None).unwrap();
+            assert_eq!(cols, vec!["total"]);
+            assert_eq!(rows.len(), 1);
+            assert_eq!(rows[0]["total"], Value::Float(30.0));
+        } else {
+            panic!("Expected Select");
+        }
+    }
+
+    #[test]
+    fn test_case_when_with_unary_minus_in_aggregate() {
+        // SUM(CASE WHEN title = 'Alpha' THEN count ELSE -count END)
+        // Alpha: 10, Beta: -5, Gamma: -20 → 10 - 5 - 20 = -15
+        let stmt = crate::query_parser::parse_query(
+            "SELECT SUM(CASE WHEN title = 'Alpha' THEN count ELSE -count END) AS net FROM test"
+        ).unwrap();
+        if let crate::query_parser::Statement::Select(q) = stmt {
+            let (rows, _) = execute(&q, &make_rows(), None).unwrap();
+            assert_eq!(rows.len(), 1);
+            assert_eq!(rows[0]["net"], Value::Float(-15.0));
         } else {
             panic!("Expected Select");
         }

--- a/crates/mdql-core/src/query_parser.rs
+++ b/crates/mdql-core/src/query_parser.rs
@@ -679,9 +679,13 @@ impl Parser {
             // Parse a general expression (could be a column, literal, or arithmetic)
             let expr = self.parse_additive()?;
 
-            // Optional AS alias
+            // Optional alias: explicit (AS alias) or implicit (just an ident)
             let alias = if self.match_keyword("AS") {
                 Some(self.parse_ident()?)
+            } else if self.peek().map_or(false, |t| {
+                t.token_type == "ident" && !self.is_clause_keyword(t)
+            }) {
+                Some(self.advance().value)
             } else {
                 None
             };
@@ -800,7 +804,11 @@ impl Parser {
                 self.expect("op", Some(")"))?;
                 Ok(expr)
             }
-            "ident" | "keyword" => {
+            "ident" => {
+                let name = self.advance().value;
+                Ok(Expr::Column(name))
+            }
+            "keyword" if !Self::is_reserved_keyword(&t.value) => {
                 let name = self.advance().value;
                 Ok(Expr::Column(name))
             }
@@ -1031,6 +1039,17 @@ impl Parser {
     fn is_clause_keyword(&self, t: &Token) -> bool {
         t.token_type == "keyword"
             && ["WHERE", "ORDER", "LIMIT", "JOIN", "ON", "GROUP"].contains(&t.value.as_str())
+    }
+
+    /// Keywords that should never be consumed as column names inside expressions.
+    fn is_reserved_keyword(kw: &str) -> bool {
+        matches!(kw,
+            "AS" | "FROM" | "WHERE" | "AND" | "OR" | "ORDER" | "BY"
+            | "ASC" | "DESC" | "LIMIT" | "JOIN" | "ON" | "GROUP"
+            | "SELECT" | "INSERT" | "INTO" | "VALUES" | "UPDATE" | "SET"
+            | "DELETE" | "ALTER" | "TABLE" | "IS" | "NOT" | "IN" | "LIKE"
+            | "RENAME" | "FIELD" | "TO" | "DROP" | "MERGE" | "FIELDS"
+        )
     }
 
     fn expect_end(&self) -> Result<(), MdqlError> {

--- a/crates/mdql-core/src/query_parser.rs
+++ b/crates/mdql-core/src/query_parser.rs
@@ -8,8 +8,59 @@ use crate::errors::MdqlError;
 // ── AST nodes ──────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, PartialEq)]
+pub enum ArithOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expr {
+    Literal(SqlValue),
+    Column(String),
+    BinaryOp { left: Box<Expr>, op: ArithOp, right: Box<Expr> },
+    UnaryMinus(Box<Expr>),
+}
+
+impl Expr {
+    /// If the expression is a simple column reference, return the name.
+    pub fn as_column(&self) -> Option<&str> {
+        match self {
+            Expr::Column(name) => Some(name),
+            _ => None,
+        }
+    }
+
+    /// A display name for this expression (used as output column name).
+    pub fn display_name(&self) -> String {
+        match self {
+            Expr::Literal(SqlValue::Int(n)) => n.to_string(),
+            Expr::Literal(SqlValue::Float(f)) => f.to_string(),
+            Expr::Literal(SqlValue::String(s)) => format!("'{}'", s),
+            Expr::Literal(SqlValue::Null) => "NULL".to_string(),
+            Expr::Literal(SqlValue::List(_)) => "list".to_string(),
+            Expr::Column(name) => name.clone(),
+            Expr::BinaryOp { left, op, right } => {
+                let op_str = match op {
+                    ArithOp::Add => "+",
+                    ArithOp::Sub => "-",
+                    ArithOp::Mul => "*",
+                    ArithOp::Div => "/",
+                    ArithOp::Mod => "%",
+                };
+                format!("{} {} {}", left.display_name(), op_str, right.display_name())
+            }
+            Expr::UnaryMinus(inner) => format!("-{}", inner.display_name()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct OrderSpec {
     pub column: String,
+    pub expr: Option<Expr>,
     pub descending: bool,
 }
 
@@ -18,6 +69,8 @@ pub struct Comparison {
     pub column: String,
     pub op: String,
     pub value: Option<SqlValue>,
+    pub left_expr: Option<Expr>,
+    pub right_expr: Option<Expr>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -63,6 +116,7 @@ pub enum AggFunc {
 pub enum SelectExpr {
     Column(String),
     Aggregate { func: AggFunc, arg: String, alias: Option<String> },
+    Expr { expr: Expr, alias: Option<String> },
 }
 
 impl SelectExpr {
@@ -82,6 +136,9 @@ impl SelectExpr {
                     };
                     format!("{}({})", func_name, arg)
                 }
+            }
+            SelectExpr::Expr { expr, alias } => {
+                alias.clone().unwrap_or_else(|| expr.display_name())
             }
         }
     }
@@ -178,8 +235,8 @@ static TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
         \s*(?:
             (?P<backtick>`[^`]+`)
             | (?P<string>'(?:[^'\\]|\\.)*')
-            | (?P<number>-?\d+(?:\.\d+)?)
-            | (?P<op><=|>=|!=|[=<>,*()])
+            | (?P<number>\d+(?:\.\d+)?)
+            | (?P<op><=|>=|!=|[=<>,*()+\-/%])
             | (?P<word>[A-Za-z_][A-Za-z0-9_./-]*)
         )"#,
     )
@@ -619,18 +676,138 @@ impl Parser {
 
             Ok(SelectExpr::Aggregate { func, arg, alias })
         } else {
-            let name = self.parse_ident()?;
-            // Optional AS alias for plain columns
-            if self.match_keyword("AS") {
-                let alias = self.parse_ident()?;
-                Ok(SelectExpr::Aggregate {
-                    func: AggFunc::Count, // Won't be used — reusing for alias
-                    arg: name.clone(),
-                    alias: Some(alias),
-                })
+            // Parse a general expression (could be a column, literal, or arithmetic)
+            let expr = self.parse_additive()?;
+
+            // Optional AS alias
+            let alias = if self.match_keyword("AS") {
+                Some(self.parse_ident()?)
             } else {
-                Ok(SelectExpr::Column(name))
+                None
+            };
+
+            // If it's a simple column reference with no alias, return Column variant
+            // for backward compatibility
+            if alias.is_none() {
+                if let Expr::Column(name) = &expr {
+                    return Ok(SelectExpr::Column(name.clone()));
+                }
             }
+
+            Ok(SelectExpr::Expr { expr, alias })
+        }
+    }
+
+    // ── Expression parser (precedence climbing) ───────────────────────
+
+    fn peek_is_additive_op(&self) -> bool {
+        self.peek().map_or(false, |t| {
+            t.token_type == "op" && (t.value == "+" || t.value == "-")
+        })
+    }
+
+    fn peek_is_multiplicative_op(&self) -> bool {
+        self.peek().map_or(false, |t| {
+            t.token_type == "op" && (t.value == "*" || t.value == "/" || t.value == "%")
+        })
+    }
+
+    fn parse_additive(&mut self) -> Result<Expr, MdqlError> {
+        let mut left = self.parse_multiplicative()?;
+        while self.peek_is_additive_op() {
+            let op_tok = self.advance();
+            let op = match op_tok.value.as_str() {
+                "+" => ArithOp::Add,
+                "-" => ArithOp::Sub,
+                _ => unreachable!(),
+            };
+            let right = self.parse_multiplicative()?;
+            left = Expr::BinaryOp {
+                left: Box::new(left),
+                op,
+                right: Box::new(right),
+            };
+        }
+        Ok(left)
+    }
+
+    fn parse_multiplicative(&mut self) -> Result<Expr, MdqlError> {
+        let mut left = self.parse_unary()?;
+        while self.peek_is_multiplicative_op() {
+            let op_tok = self.advance();
+            let op = match op_tok.value.as_str() {
+                "*" => ArithOp::Mul,
+                "/" => ArithOp::Div,
+                "%" => ArithOp::Mod,
+                _ => unreachable!(),
+            };
+            let right = self.parse_unary()?;
+            left = Expr::BinaryOp {
+                left: Box::new(left),
+                op,
+                right: Box::new(right),
+            };
+        }
+        Ok(left)
+    }
+
+    fn parse_unary(&mut self) -> Result<Expr, MdqlError> {
+        if self.peek().map_or(false, |t| t.token_type == "op" && t.value == "-") {
+            self.advance();
+            let inner = self.parse_atom()?;
+            // Fold unary minus on literals
+            match inner {
+                Expr::Literal(SqlValue::Int(n)) => Ok(Expr::Literal(SqlValue::Int(-n))),
+                Expr::Literal(SqlValue::Float(f)) => Ok(Expr::Literal(SqlValue::Float(-f))),
+                _ => Ok(Expr::UnaryMinus(Box::new(inner))),
+            }
+        } else {
+            self.parse_atom()
+        }
+    }
+
+    fn parse_atom(&mut self) -> Result<Expr, MdqlError> {
+        let t = self.peek().ok_or_else(|| {
+            MdqlError::QueryParse("Expected expression, got end of query".into())
+        })?;
+
+        match t.token_type.as_str() {
+            "number" => {
+                let v = self.advance().value;
+                if v.contains('.') {
+                    let f: f64 = v.parse().map_err(|_| {
+                        MdqlError::QueryParse(format!("Invalid float: {}", v))
+                    })?;
+                    Ok(Expr::Literal(SqlValue::Float(f)))
+                } else {
+                    let n: i64 = v.parse().map_err(|_| {
+                        MdqlError::QueryParse(format!("Invalid int: {}", v))
+                    })?;
+                    Ok(Expr::Literal(SqlValue::Int(n)))
+                }
+            }
+            "string" => {
+                let v = self.advance().value;
+                Ok(Expr::Literal(SqlValue::String(v)))
+            }
+            "keyword" if t.value == "NULL" => {
+                self.advance();
+                Ok(Expr::Literal(SqlValue::Null))
+            }
+            "op" if t.value == "(" => {
+                self.advance();
+                let expr = self.parse_additive()?;
+                self.expect("op", Some(")"))?;
+                Ok(expr)
+            }
+            "ident" | "keyword" => {
+                let name = self.advance().value;
+                Ok(Expr::Column(name))
+            }
+            _ => Err(MdqlError::QueryParse(format!(
+                "Expected expression, got '{}'",
+                t.raw
+            ))),
         }
     }
 
@@ -677,17 +854,28 @@ impl Parser {
     }
 
     fn parse_comparison(&mut self) -> Result<WhereClause, MdqlError> {
-        // Handle parenthesized expressions
+        // Handle parenthesized boolean expressions
         if self.peek().map_or(false, |t| t.token_type == "op" && t.value == "(") {
+            // Save position — might be arithmetic parens, not boolean
+            let saved_pos = self.pos;
             self.advance();
-            let expr = self.parse_or_expr()?;
-            self.expect("op", Some(")"))?;
-            return Ok(expr);
+            // Try parsing as boolean (OR/AND) expression
+            let result = self.parse_or_expr();
+            if result.is_ok() && self.peek().map_or(false, |t| t.token_type == "op" && t.value == ")") {
+                self.advance();
+                return result;
+            }
+            // Not a boolean paren — rewind and parse as arithmetic expression
+            self.pos = saved_pos;
         }
 
-        let col = self.parse_ident()?;
+        // Parse the left side as a full expression (column, literal, or arithmetic)
+        let left_expr = self.parse_additive()?;
 
-        // IS NULL / IS NOT NULL
+        // Extract column name for backward compat (simple column on left side)
+        let col = left_expr.as_column().unwrap_or("").to_string();
+
+        // IS NULL / IS NOT NULL (only valid with simple column)
         if self.match_keyword("IS") {
             if self.match_keyword("NOT") {
                 self.expect("keyword", Some("NULL"))?;
@@ -695,6 +883,8 @@ impl Parser {
                     column: col,
                     op: "IS NOT NULL".into(),
                     value: None,
+                    left_expr: Some(left_expr),
+                    right_expr: None,
                 }));
             }
             self.expect("keyword", Some("NULL"))?;
@@ -702,6 +892,8 @@ impl Parser {
                 column: col,
                 op: "IS NULL".into(),
                 value: None,
+                left_expr: Some(left_expr),
+                right_expr: None,
             }));
         }
 
@@ -718,6 +910,8 @@ impl Parser {
                 column: col,
                 op: "IN".into(),
                 value: Some(SqlValue::List(values)),
+                left_expr: Some(left_expr),
+                right_expr: None,
             }));
         }
 
@@ -728,6 +922,8 @@ impl Parser {
                 column: col,
                 op: "LIKE".into(),
                 value: Some(val),
+                left_expr: Some(left_expr),
+                right_expr: None,
             }));
         }
 
@@ -739,21 +935,31 @@ impl Parser {
                     column: col,
                     op: "NOT LIKE".into(),
                     value: Some(val),
+                    left_expr: Some(left_expr),
+                    right_expr: None,
                 }));
             }
             return Err(MdqlError::QueryParse("Expected LIKE after NOT".into()));
         }
 
-        // Standard operators
+        // Standard comparison operators
         if let Some(t) = self.peek() {
             if t.token_type == "op" && ["=", "!=", "<", ">", "<=", ">="].contains(&t.value.as_str())
             {
                 let op = self.advance().value;
-                let val = self.parse_value()?;
+                // Parse right side as expression
+                let right_expr = self.parse_additive()?;
+                // Extract SqlValue for backward compat (simple literal on right side)
+                let value = match &right_expr {
+                    Expr::Literal(v) => Some(v.clone()),
+                    _ => None,
+                };
                 return Ok(WhereClause::Comparison(Comparison {
                     column: col,
                     op,
-                    value: Some(val),
+                    value,
+                    left_expr: Some(left_expr),
+                    right_expr: Some(right_expr),
                 }));
             }
         }
@@ -761,7 +967,7 @@ impl Parser {
         let got = self.peek().map_or("end".to_string(), |t| t.raw.clone());
         Err(MdqlError::QueryParse(format!(
             "Expected operator after '{}', got '{}'",
-            col, got
+            left_expr.display_name(), got
         )))
     }
 
@@ -807,7 +1013,8 @@ impl Parser {
     }
 
     fn parse_order_spec(&mut self) -> Result<OrderSpec, MdqlError> {
-        let col = self.parse_ident()?;
+        let expr = self.parse_additive()?;
+        let col = expr.as_column().unwrap_or("").to_string();
         let descending = if self.match_keyword("DESC") {
             true
         } else {
@@ -816,6 +1023,7 @@ impl Parser {
         };
         Ok(OrderSpec {
             column: col,
+            expr: Some(expr),
             descending,
         })
     }
@@ -1140,6 +1348,235 @@ mod tests {
                 panic!("Expected Named columns");
             }
             assert_eq!(q.group_by, None);
+        } else {
+            panic!("Expected Select");
+        }
+    }
+
+    // ── Expression tests ──────────────────────────────────────────
+
+    #[test]
+    fn test_select_arithmetic_expr() {
+        let stmt = parse_query("SELECT a + b FROM test").unwrap();
+        if let Statement::Select(q) = stmt {
+            if let ColumnList::Named(exprs) = &q.columns {
+                assert_eq!(exprs.len(), 1);
+                assert!(matches!(&exprs[0], SelectExpr::Expr {
+                    expr: Expr::BinaryOp { op: ArithOp::Add, .. },
+                    alias: None,
+                }));
+            } else {
+                panic!("Expected Named columns");
+            }
+        } else {
+            panic!("Expected Select");
+        }
+    }
+
+    #[test]
+    fn test_select_arithmetic_with_alias() {
+        let stmt = parse_query("SELECT a + b AS total FROM test").unwrap();
+        if let Statement::Select(q) = stmt {
+            if let ColumnList::Named(exprs) = &q.columns {
+                assert_eq!(exprs.len(), 1);
+                assert!(matches!(&exprs[0], SelectExpr::Expr {
+                    alias: Some(a),
+                    ..
+                } if a == "total"));
+                assert_eq!(exprs[0].output_name(), "total");
+            } else {
+                panic!("Expected Named columns");
+            }
+        } else {
+            panic!("Expected Select");
+        }
+    }
+
+    #[test]
+    fn test_select_precedence() {
+        // a + b * c should parse as a + (b * c)
+        let stmt = parse_query("SELECT a + b * c FROM test").unwrap();
+        if let Statement::Select(q) = stmt {
+            if let ColumnList::Named(exprs) = &q.columns {
+                if let SelectExpr::Expr { expr, .. } = &exprs[0] {
+                    if let Expr::BinaryOp { left, op, right } = expr {
+                        assert_eq!(*op, ArithOp::Add);
+                        assert!(matches!(left.as_ref(), Expr::Column(n) if n == "a"));
+                        assert!(matches!(right.as_ref(), Expr::BinaryOp { op: ArithOp::Mul, .. }));
+                    } else {
+                        panic!("Expected BinaryOp");
+                    }
+                } else {
+                    panic!("Expected Expr variant");
+                }
+            } else {
+                panic!("Expected Named columns");
+            }
+        } else {
+            panic!("Expected Select");
+        }
+    }
+
+    #[test]
+    fn test_select_parenthesized_expr() {
+        // (a + b) * c should override default precedence
+        let stmt = parse_query("SELECT (a + b) * c FROM test").unwrap();
+        if let Statement::Select(q) = stmt {
+            if let ColumnList::Named(exprs) = &q.columns {
+                if let SelectExpr::Expr { expr, .. } = &exprs[0] {
+                    if let Expr::BinaryOp { left, op, .. } = expr {
+                        assert_eq!(*op, ArithOp::Mul);
+                        assert!(matches!(left.as_ref(), Expr::BinaryOp { op: ArithOp::Add, .. }));
+                    } else {
+                        panic!("Expected BinaryOp");
+                    }
+                } else {
+                    panic!("Expected Expr variant");
+                }
+            } else {
+                panic!("Expected Named columns");
+            }
+        } else {
+            panic!("Expected Select");
+        }
+    }
+
+    #[test]
+    fn test_select_unary_minus() {
+        let stmt = parse_query("SELECT -count FROM test").unwrap();
+        if let Statement::Select(q) = stmt {
+            if let ColumnList::Named(exprs) = &q.columns {
+                assert!(matches!(&exprs[0], SelectExpr::Expr {
+                    expr: Expr::UnaryMinus(_),
+                    ..
+                }));
+            } else {
+                panic!("Expected Named columns");
+            }
+        } else {
+            panic!("Expected Select");
+        }
+    }
+
+    #[test]
+    fn test_select_negative_literal() {
+        let stmt = parse_query("SELECT -42 FROM test").unwrap();
+        if let Statement::Select(q) = stmt {
+            if let ColumnList::Named(exprs) = &q.columns {
+                // Unary minus folds into the literal
+                assert!(matches!(&exprs[0], SelectExpr::Expr {
+                    expr: Expr::Literal(SqlValue::Int(-42)),
+                    ..
+                }));
+            } else {
+                panic!("Expected Named columns");
+            }
+        } else {
+            panic!("Expected Select");
+        }
+    }
+
+    #[test]
+    fn test_where_arithmetic_expr() {
+        let stmt = parse_query("SELECT * FROM test WHERE a + b > 10").unwrap();
+        if let Statement::Select(q) = stmt {
+            if let Some(WhereClause::Comparison(c)) = q.where_clause {
+                assert_eq!(c.op, ">");
+                assert!(matches!(&c.left_expr, Some(Expr::BinaryOp { op: ArithOp::Add, .. })));
+                assert!(matches!(&c.right_expr, Some(Expr::Literal(SqlValue::Int(10)))));
+            } else {
+                panic!("Expected comparison");
+            }
+        } else {
+            panic!("Expected Select");
+        }
+    }
+
+    #[test]
+    fn test_where_both_sides_expr() {
+        let stmt = parse_query("SELECT * FROM test WHERE a * 2 > b + 1").unwrap();
+        if let Statement::Select(q) = stmt {
+            if let Some(WhereClause::Comparison(c)) = q.where_clause {
+                assert_eq!(c.op, ">");
+                assert!(matches!(&c.left_expr, Some(Expr::BinaryOp { op: ArithOp::Mul, .. })));
+                assert!(matches!(&c.right_expr, Some(Expr::BinaryOp { op: ArithOp::Add, .. })));
+            } else {
+                panic!("Expected comparison");
+            }
+        } else {
+            panic!("Expected Select");
+        }
+    }
+
+    #[test]
+    fn test_order_by_expr() {
+        let stmt = parse_query("SELECT * FROM test ORDER BY a + b DESC").unwrap();
+        if let Statement::Select(q) = stmt {
+            let ob = q.order_by.unwrap();
+            assert_eq!(ob.len(), 1);
+            assert!(ob[0].descending);
+            assert!(matches!(&ob[0].expr, Some(Expr::BinaryOp { op: ArithOp::Add, .. })));
+        } else {
+            panic!("Expected Select");
+        }
+    }
+
+    #[test]
+    fn test_all_arithmetic_ops() {
+        let stmt = parse_query("SELECT a + b, a - b, a * b, a / b, a % b FROM test").unwrap();
+        if let Statement::Select(q) = stmt {
+            if let ColumnList::Named(exprs) = &q.columns {
+                assert_eq!(exprs.len(), 5);
+                assert!(matches!(&exprs[0], SelectExpr::Expr { expr: Expr::BinaryOp { op: ArithOp::Add, .. }, .. }));
+                assert!(matches!(&exprs[1], SelectExpr::Expr { expr: Expr::BinaryOp { op: ArithOp::Sub, .. }, .. }));
+                assert!(matches!(&exprs[2], SelectExpr::Expr { expr: Expr::BinaryOp { op: ArithOp::Mul, .. }, .. }));
+                assert!(matches!(&exprs[3], SelectExpr::Expr { expr: Expr::BinaryOp { op: ArithOp::Div, .. }, .. }));
+                assert!(matches!(&exprs[4], SelectExpr::Expr { expr: Expr::BinaryOp { op: ArithOp::Mod, .. }, .. }));
+            } else {
+                panic!("Expected Named columns");
+            }
+        } else {
+            panic!("Expected Select");
+        }
+    }
+
+    #[test]
+    fn test_column_with_literal_arithmetic() {
+        let stmt = parse_query("SELECT count * 2 + 1 FROM test").unwrap();
+        if let Statement::Select(q) = stmt {
+            if let ColumnList::Named(exprs) = &q.columns {
+                // Should be (count * 2) + 1
+                if let SelectExpr::Expr { expr, .. } = &exprs[0] {
+                    if let Expr::BinaryOp { left, op, right } = expr {
+                        assert_eq!(*op, ArithOp::Add);
+                        assert!(matches!(right.as_ref(), Expr::Literal(SqlValue::Int(1))));
+                        assert!(matches!(left.as_ref(), Expr::BinaryOp { op: ArithOp::Mul, .. }));
+                    } else {
+                        panic!("Expected BinaryOp");
+                    }
+                } else {
+                    panic!("Expected Expr");
+                }
+            } else {
+                panic!("Expected Named columns");
+            }
+        } else {
+            panic!("Expected Select");
+        }
+    }
+
+    #[test]
+    fn test_mixed_columns_and_exprs() {
+        let stmt = parse_query("SELECT title, a + b AS sum, count FROM test").unwrap();
+        if let Statement::Select(q) = stmt {
+            if let ColumnList::Named(exprs) = &q.columns {
+                assert_eq!(exprs.len(), 3);
+                assert_eq!(exprs[0], SelectExpr::Column("title".into()));
+                assert!(matches!(&exprs[1], SelectExpr::Expr { alias: Some(a), .. } if a == "sum"));
+                assert_eq!(exprs[2], SelectExpr::Column("count".into()));
+            } else {
+                panic!("Expected Named columns");
+            }
         } else {
             panic!("Expected Select");
         }

--- a/crates/mdql-core/src/query_parser.rs
+++ b/crates/mdql-core/src/query_parser.rs
@@ -22,15 +22,13 @@ pub enum Expr {
     Column(String),
     BinaryOp { left: Box<Expr>, op: ArithOp, right: Box<Expr> },
     UnaryMinus(Box<Expr>),
+    Case { whens: Vec<(WhereClause, Box<Expr>)>, else_expr: Option<Box<Expr>> },
 }
 
 impl Expr {
     /// If the expression is a simple column reference, return the name.
     pub fn as_column(&self) -> Option<&str> {
-        match self {
-            Expr::Column(name) => Some(name),
-            _ => None,
-        }
+        if let Expr::Column(name) = self { Some(name) } else { None }
     }
 
     /// A display name for this expression (used as output column name).
@@ -53,6 +51,7 @@ impl Expr {
                 format!("{} {} {}", left.display_name(), op_str, right.display_name())
             }
             Expr::UnaryMinus(inner) => format!("-{}", inner.display_name()),
+            Expr::Case { .. } => "CASE".to_string(),
         }
     }
 }
@@ -115,7 +114,7 @@ pub enum AggFunc {
 #[derive(Debug, Clone, PartialEq)]
 pub enum SelectExpr {
     Column(String),
-    Aggregate { func: AggFunc, arg: String, alias: Option<String> },
+    Aggregate { func: AggFunc, arg: String, arg_expr: Option<Expr>, alias: Option<String> },
     Expr { expr: Expr, alias: Option<String> },
 }
 
@@ -123,7 +122,7 @@ impl SelectExpr {
     pub fn output_name(&self) -> String {
         match self {
             SelectExpr::Column(name) => name.clone(),
-            SelectExpr::Aggregate { func, arg, alias } => {
+            SelectExpr::Aggregate { func, arg, alias, .. } => {
                 if let Some(a) = alias {
                     a.clone()
                 } else {
@@ -225,6 +224,7 @@ static KEYWORDS: &[&str] = &[
     "JOIN", "ON", "AS", "GROUP",
     "INSERT", "INTO", "VALUES", "UPDATE", "SET", "DELETE",
     "ALTER", "TABLE", "RENAME", "FIELD", "TO", "DROP", "MERGE", "FIELDS",
+    "CASE", "WHEN", "THEN", "ELSE", "END",
 ];
 
 static AGG_FUNCS: &[&str] = &["COUNT", "SUM", "AVG", "MIN", "MAX"];
@@ -660,21 +660,31 @@ impl Parser {
                 _ => unreachable!(),
             };
             self.expect("op", Some("("))?;
-            let arg = if self.peek().map_or(false, |t| t.token_type == "op" && t.value == "*") {
+            let (arg, arg_expr) = if self.peek().map_or(false, |t| t.token_type == "op" && t.value == "*") {
                 self.advance();
-                "*".to_string()
+                ("*".to_string(), None)
             } else {
-                self.parse_ident()?
+                // Parse a full expression inside the aggregate (supports CASE WHEN, arithmetic, etc.)
+                let expr = self.parse_additive()?;
+                if let Expr::Column(name) = &expr {
+                    (name.clone(), None)
+                } else {
+                    (expr.display_name(), Some(expr))
+                }
             };
             self.expect("op", Some(")"))?;
 
             let alias = if self.match_keyword("AS") {
                 Some(self.parse_ident()?)
+            } else if self.peek().map_or(false, |t| {
+                t.token_type == "ident" && !self.is_clause_keyword(t)
+            }) {
+                Some(self.advance().value)
             } else {
                 None
             };
 
-            Ok(SelectExpr::Aggregate { func, arg, alias })
+            Ok(SelectExpr::Aggregate { func, arg, arg_expr, alias })
         } else {
             // Parse a general expression (could be a column, literal, or arithmetic)
             let expr = self.parse_additive()?;
@@ -798,6 +808,9 @@ impl Parser {
                 self.advance();
                 Ok(Expr::Literal(SqlValue::Null))
             }
+            "keyword" if t.value == "CASE" => {
+                self.parse_case_expr()
+            }
             "op" if t.value == "(" => {
                 self.advance();
                 let expr = self.parse_additive()?;
@@ -817,6 +830,27 @@ impl Parser {
                 t.raw
             ))),
         }
+    }
+
+    fn parse_case_expr(&mut self) -> Result<Expr, MdqlError> {
+        self.expect("keyword", Some("CASE"))?;
+        let mut whens = Vec::new();
+        while self.match_keyword("WHEN") {
+            let condition = self.parse_or_expr()?;
+            self.expect("keyword", Some("THEN"))?;
+            let result = self.parse_additive()?;
+            whens.push((condition, Box::new(result)));
+        }
+        if whens.is_empty() {
+            return Err(MdqlError::QueryParse("CASE requires at least one WHEN clause".into()));
+        }
+        let else_expr = if self.match_keyword("ELSE") {
+            Some(Box::new(self.parse_additive()?))
+        } else {
+            None
+        };
+        self.expect("keyword", Some("END"))?;
+        Ok(Expr::Case { whens, else_expr })
     }
 
     fn parse_ident(&mut self) -> Result<String, MdqlError> {
@@ -1049,6 +1083,7 @@ impl Parser {
             | "SELECT" | "INSERT" | "INTO" | "VALUES" | "UPDATE" | "SET"
             | "DELETE" | "ALTER" | "TABLE" | "IS" | "NOT" | "IN" | "LIKE"
             | "RENAME" | "FIELD" | "TO" | "DROP" | "MERGE" | "FIELDS"
+            | "CASE" | "WHEN" | "THEN" | "ELSE" | "END"
         )
     }
 
@@ -1333,6 +1368,7 @@ mod tests {
                     func: AggFunc::Count,
                     arg,
                     alias: Some(a),
+                    ..
                 } if arg == "*" && a == "cnt"));
             } else {
                 panic!("Expected Named columns");
@@ -1593,6 +1629,111 @@ mod tests {
                 assert_eq!(exprs[0], SelectExpr::Column("title".into()));
                 assert!(matches!(&exprs[1], SelectExpr::Expr { alias: Some(a), .. } if a == "sum"));
                 assert_eq!(exprs[2], SelectExpr::Column("count".into()));
+            } else {
+                panic!("Expected Named columns");
+            }
+        } else {
+            panic!("Expected Select");
+        }
+    }
+
+    // ── CASE WHEN tests ──────────────────────────────────────────
+
+    #[test]
+    fn test_case_when_basic() {
+        let stmt = parse_query(
+            "SELECT CASE WHEN status = 'ACTIVE' THEN 1 ELSE 0 END FROM test"
+        ).unwrap();
+        if let Statement::Select(q) = stmt {
+            if let ColumnList::Named(exprs) = &q.columns {
+                assert_eq!(exprs.len(), 1);
+                assert!(matches!(&exprs[0], SelectExpr::Expr {
+                    expr: Expr::Case { .. },
+                    ..
+                }));
+            } else {
+                panic!("Expected Named columns");
+            }
+        } else {
+            panic!("Expected Select");
+        }
+    }
+
+    #[test]
+    fn test_case_when_multiple_branches() {
+        let stmt = parse_query(
+            "SELECT CASE WHEN x > 10 THEN 'high' WHEN x > 5 THEN 'mid' ELSE 'low' END FROM test"
+        ).unwrap();
+        if let Statement::Select(q) = stmt {
+            if let ColumnList::Named(exprs) = &q.columns {
+                if let SelectExpr::Expr { expr: Expr::Case { whens, else_expr }, .. } = &exprs[0] {
+                    assert_eq!(whens.len(), 2);
+                    assert!(else_expr.is_some());
+                } else {
+                    panic!("Expected Case expression");
+                }
+            } else {
+                panic!("Expected Named columns");
+            }
+        } else {
+            panic!("Expected Select");
+        }
+    }
+
+    #[test]
+    fn test_case_when_no_else() {
+        let stmt = parse_query(
+            "SELECT CASE WHEN x = 1 THEN 'one' END FROM test"
+        ).unwrap();
+        if let Statement::Select(q) = stmt {
+            if let ColumnList::Named(exprs) = &q.columns {
+                if let SelectExpr::Expr { expr: Expr::Case { whens, else_expr }, .. } = &exprs[0] {
+                    assert_eq!(whens.len(), 1);
+                    assert!(else_expr.is_none());
+                } else {
+                    panic!("Expected Case expression");
+                }
+            } else {
+                panic!("Expected Named columns");
+            }
+        } else {
+            panic!("Expected Select");
+        }
+    }
+
+    #[test]
+    fn test_case_when_in_aggregate() {
+        let stmt = parse_query(
+            "SELECT SUM(CASE WHEN side = 'BUY' THEN size ELSE -size END) AS net FROM orders GROUP BY token"
+        ).unwrap();
+        if let Statement::Select(q) = stmt {
+            if let ColumnList::Named(exprs) = &q.columns {
+                assert_eq!(exprs.len(), 1);
+                assert!(matches!(&exprs[0], SelectExpr::Aggregate {
+                    func: AggFunc::Sum,
+                    arg_expr: Some(Expr::Case { .. }),
+                    alias: Some(a),
+                    ..
+                } if a == "net"));
+            } else {
+                panic!("Expected Named columns");
+            }
+        } else {
+            panic!("Expected Select");
+        }
+    }
+
+    #[test]
+    fn test_case_when_with_alias() {
+        let stmt = parse_query(
+            "SELECT CASE WHEN x > 0 THEN 'pos' ELSE 'neg' END AS sign FROM test"
+        ).unwrap();
+        if let Statement::Select(q) = stmt {
+            if let ColumnList::Named(exprs) = &q.columns {
+                assert!(matches!(&exprs[0], SelectExpr::Expr {
+                    expr: Expr::Case { .. },
+                    alias: Some(a),
+                } if a == "sign"));
             } else {
                 panic!("Expected Named columns");
             }

--- a/crates/mdql-web/Cargo.toml
+++ b/crates/mdql-web/Cargo.toml
@@ -16,7 +16,7 @@ name = "mdql-web"
 path = "src/main.rs"
 
 [dependencies]
-mdql-core = { path = "../mdql-core", version = "0.1.0" }
+mdql-core = { path = "../mdql-core", version = "0.2.0" }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.6", features = ["cors"] }

--- a/crates/mdql/Cargo.toml
+++ b/crates/mdql/Cargo.toml
@@ -16,8 +16,8 @@ name = "mdql"
 path = "src/main.rs"
 
 [dependencies]
-mdql-core = { path = "../mdql-core", version = "0.1.0" }
-mdql-web = { path = "../mdql-web", version = "0.1.0" }
+mdql-core = { path = "../mdql-core", version = "0.2.0" }
+mdql-web = { path = "../mdql-web", version = "0.2.0" }
 clap = { version = "4", features = ["derive"] }
 comfy-table = "7"
 serde_json = "1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "mdql"
-version = "0.1.0"
+version = "0.2.0"
 description = "MDQL — a queryable database where every entry is a markdown file"
 requires-python = ">=3.8"
 license = "AGPL-3.0-only"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdql-python"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 publish = false
 
@@ -9,7 +9,7 @@ name = "mdql"
 crate-type = ["cdylib"]
 
 [dependencies]
-mdql-core = { path = "../crates/mdql-core", version = "0.1.0" }
+mdql-core = { path = "../crates/mdql-core", version = "0.2.0" }
 pyo3 = { version = "0.23", features = ["extension-module"] }
 chrono = "0.4"
 serde_yaml = "0.9"

--- a/tests/test_rust_python_alignment.py
+++ b/tests/test_rust_python_alignment.py
@@ -1,0 +1,266 @@
+"""Tests that Rust CLI and Python API produce identical results.
+
+These tests run the same operations through both the Rust CLI (via subprocess)
+and the Python API, then compare the outputs to catch any divergence.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mdql.api import Database, Table
+from mdql.loader import load_table
+from mdql.schema import load_schema
+
+FIXTURES = Path(__file__).parent / "fixtures"
+EXAMPLES = Path(__file__).parent.parent / "examples"
+
+MDQL_BIN = Path(__file__).parent.parent / "target" / "debug" / "mdql"
+
+
+def run_cli(args: list[str]) -> str:
+    """Run the mdql CLI and return stdout."""
+    result = subprocess.run(
+        [str(MDQL_BIN)] + args,
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"CLI failed: {result.stderr}")
+    return result.stdout
+
+
+def cli_query_json(folder: str, sql: str) -> list[dict]:
+    """Run a CLI query with --format json and parse the result."""
+    output = run_cli(["query", folder, sql, "--format", "json"])
+    return json.loads(output)
+
+
+@pytest.fixture(autouse=True)
+def require_cli():
+    """Skip all tests if the CLI binary hasn't been built."""
+    if not MDQL_BIN.exists():
+        pytest.skip("mdql CLI not built — run `cargo build` first")
+
+
+class TestSchemaAlignment:
+    """Schema loading produces the same structure in both Rust and Python."""
+
+    def test_schema_filename(self):
+        """Both use _mdql.md as the schema filename."""
+        from mdql._native import RustTable
+        t = RustTable(str(FIXTURES / "valid_table"))
+        assert t.name == "notes"
+        # CLI should also find the schema
+        output = run_cli(["validate", str(FIXTURES / "valid_table")])
+        assert "valid" in output.lower()
+
+    def test_schema_fields_match(self):
+        """Python schema fields match what CLI reports."""
+        schema = load_schema(FIXTURES / "valid_table")
+        cli_output = run_cli(["schema", str(FIXTURES / "valid_table")])
+        for field_name in schema.frontmatter:
+            assert field_name in cli_output
+
+    def test_schema_table_name(self):
+        """Table name matches between Python and CLI."""
+        schema = load_schema(FIXTURES / "valid_table")
+        cli_output = run_cli(["schema", str(FIXTURES / "valid_table")])
+        assert schema.table in cli_output
+
+
+class TestQueryAlignment:
+    """Same SQL query returns the same data from CLI and Python API."""
+
+    def test_select_star_row_count(self):
+        table = Table(FIXTURES / "valid_table")
+        py_rows, _ = table.query("SELECT * FROM notes")
+        cli_rows = cli_query_json(str(FIXTURES / "valid_table"), "SELECT * FROM notes")
+        assert len(py_rows) == len(cli_rows)
+
+    def test_select_columns_match(self):
+        table = Table(FIXTURES / "valid_table")
+        py_rows, py_cols = table.query("SELECT title, author FROM notes")
+        cli_rows = cli_query_json(
+            str(FIXTURES / "valid_table"),
+            "SELECT title, author FROM notes",
+        )
+        assert py_cols == ["title", "author"]
+        assert set(cli_rows[0].keys()) == {"title", "author"}
+
+    def test_select_values_match(self):
+        table = Table(FIXTURES / "valid_table")
+        py_rows, _ = table.query("SELECT title FROM notes ORDER BY title ASC")
+        cli_rows = cli_query_json(
+            str(FIXTURES / "valid_table"),
+            "SELECT title FROM notes ORDER BY title ASC",
+        )
+        py_titles = [r["title"] for r in py_rows]
+        cli_titles = [r["title"] for r in cli_rows]
+        assert py_titles == cli_titles
+
+    def test_where_filter_match(self):
+        table = Table(FIXTURES / "valid_table")
+        py_rows, _ = table.query(
+            "SELECT title FROM notes WHERE status = 'draft' ORDER BY title ASC"
+        )
+        cli_rows = cli_query_json(
+            str(FIXTURES / "valid_table"),
+            "SELECT title FROM notes WHERE status = 'draft' ORDER BY title ASC",
+        )
+        py_titles = [r["title"] for r in py_rows]
+        cli_titles = [r["title"] for r in cli_rows]
+        assert py_titles == cli_titles
+
+    def test_limit_match(self):
+        table = Table(FIXTURES / "valid_table")
+        py_rows, _ = table.query("SELECT title FROM notes LIMIT 2")
+        cli_rows = cli_query_json(
+            str(FIXTURES / "valid_table"),
+            "SELECT title FROM notes LIMIT 2",
+        )
+        assert len(py_rows) == len(cli_rows) == 2
+
+    def test_order_by_desc_match(self):
+        table = Table(FIXTURES / "valid_table")
+        py_rows, _ = table.query("SELECT title FROM notes ORDER BY title DESC")
+        cli_rows = cli_query_json(
+            str(FIXTURES / "valid_table"),
+            "SELECT title FROM notes ORDER BY title DESC",
+        )
+        py_titles = [r["title"] for r in py_rows]
+        cli_titles = [r["title"] for r in cli_rows]
+        assert py_titles == cli_titles
+
+
+class TestLoadAlignment:
+    """Table.load() matches CLI row counts and data."""
+
+    def test_row_count(self):
+        py_schema, py_rows, py_errors = load_table(FIXTURES / "valid_table")
+        cli_rows = cli_query_json(
+            str(FIXTURES / "valid_table"),
+            "SELECT * FROM notes",
+        )
+        assert len(py_rows) == len(cli_rows)
+
+    def test_field_values(self):
+        """Spot-check that field values are identical."""
+        py_schema, py_rows, _ = load_table(FIXTURES / "valid_table")
+        cli_rows = cli_query_json(
+            str(FIXTURES / "valid_table"),
+            "SELECT path, title, author FROM notes ORDER BY path ASC",
+        )
+        py_sorted = sorted(py_rows, key=lambda r: r["path"])
+        for py_row, cli_row in zip(py_sorted, cli_rows):
+            assert py_row["title"] == cli_row["title"]
+            assert py_row["author"] == cli_row["author"]
+
+
+class TestValidationAlignment:
+    """Validation produces consistent results."""
+
+    def test_valid_table(self):
+        table = Table(FIXTURES / "valid_table")
+        py_errors = table.validate()
+        cli_output = run_cli(["validate", str(FIXTURES / "valid_table")])
+        if len(py_errors) == 0:
+            assert "valid" in cli_output.lower()
+
+    def test_invalid_table(self):
+        table = Table(FIXTURES / "invalid_table")
+        py_errors = table.validate()
+        result = subprocess.run(
+            [str(MDQL_BIN), "validate", str(FIXTURES / "invalid_table")],
+            capture_output=True, text=True,
+        )
+        # Both should report errors
+        assert len(py_errors) > 0
+        assert result.returncode != 0 or "error" in result.stderr.lower() or "invalid" in result.stdout.lower()
+
+
+class TestWriteAlignment:
+    """Insert/update through Python produces files the CLI can read."""
+
+    def test_python_insert_cli_reads(self, tmp_path):
+        (tmp_path / "_mdql.md").write_text(
+            "---\ntype: schema\ntable: items\n"
+            "frontmatter:\n"
+            "  title:\n    type: string\n    required: true\n"
+            "  count:\n    type: int\n    required: false\n"
+            "h1:\n  required: false\n---\n"
+        )
+        table = Table(tmp_path)
+        table.insert({"title": "Test Item", "count": 42})
+
+        # CLI should be able to query this file
+        cli_rows = cli_query_json(
+            str(tmp_path),
+            "SELECT title, count FROM items",
+        )
+        assert len(cli_rows) == 1
+        assert cli_rows[0]["title"] == "Test Item"
+        assert cli_rows[0]["count"] == 42
+
+    def test_python_insert_cli_validates(self, tmp_path):
+        (tmp_path / "_mdql.md").write_text(
+            "---\ntype: schema\ntable: items\n"
+            "frontmatter:\n"
+            "  title:\n    type: string\n    required: true\n"
+            "h1:\n  required: false\n---\n"
+        )
+        table = Table(tmp_path)
+        table.insert({"title": "Valid Item"})
+
+        output = run_cli(["validate", str(tmp_path)])
+        assert "valid" in output.lower()
+
+    def test_cli_insert_python_reads(self, tmp_path):
+        (tmp_path / "_mdql.md").write_text(
+            "---\ntype: schema\ntable: items\n"
+            "frontmatter:\n"
+            "  title:\n    type: string\n    required: true\n"
+            "  count:\n    type: int\n    required: false\n"
+            "h1:\n  required: false\n---\n"
+        )
+        run_cli([
+            "query", str(tmp_path),
+            "INSERT INTO items (title, count) VALUES ('CLI Item', 99)",
+        ])
+
+        table = Table(tmp_path)
+        rows, errors = table.load()
+        assert len(rows) == 1
+        assert rows[0]["title"] == "CLI Item"
+        assert rows[0]["count"] == 99
+
+
+@pytest.mark.skipif(
+    not (EXAMPLES / "_mdql.md").exists(),
+    reason="example data not present",
+)
+class TestExamplesAlignment:
+    """Alignment tests on the real example data."""
+
+    def test_strategies_row_count(self):
+        table = Table(EXAMPLES / "strategies")
+        py_rows, _ = table.load()
+        cli_rows = cli_query_json(
+            str(EXAMPLES / "strategies"),
+            "SELECT * FROM strategies",
+        )
+        assert len(py_rows) == len(cli_rows)
+
+    def test_database_query_match(self):
+        db = Database(EXAMPLES)
+        py_rows, py_cols = db.query(
+            "SELECT title, composite FROM strategies ORDER BY composite DESC LIMIT 5"
+        )
+        cli_rows = cli_query_json(
+            str(EXAMPLES),
+            "SELECT title, composite FROM strategies ORDER BY composite DESC LIMIT 5",
+        )
+        py_titles = [r["title"] for r in py_rows]
+        cli_titles = [r["title"] for r in cli_rows]
+        assert py_titles == cli_titles


### PR DESCRIPTION
## Summary
- Add arithmetic expression support (`+`, `-`, `*`, `/`, `%`) in SELECT, WHERE, and ORDER BY clauses following PostgreSQL semantics
- Add Rust/Python alignment test suite (18 tests verifying CLI and Python API produce identical results)
- Add install section to README (Cargo, Homebrew, pip)

## Test plan
- [x] 93 unit tests pass (22 new expression tests)
- [x] CLI end-to-end smoke test with computed expressions
- [x] All existing parser, engine, and validator tests still pass
- [ ] Python alignment tests (require `cargo build` + maturin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)