### PR TITLE
v0.2.1 — fix sdist license inclusion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/mdql-db/mdql"

--- a/crates/mdql-web/Cargo.toml
+++ b/crates/mdql-web/Cargo.toml
@@ -16,7 +16,7 @@ name = "mdql-web"
 path = "src/main.rs"
 
 [dependencies]
-mdql-core = { path = "../mdql-core", version = "0.2.0" }
+mdql-core = { path = "../mdql-core", version = "0.2.1" }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.6", features = ["cors"] }

--- a/crates/mdql/Cargo.toml
+++ b/crates/mdql/Cargo.toml
@@ -16,8 +16,8 @@ name = "mdql"
 path = "src/main.rs"
 
 [dependencies]
-mdql-core = { path = "../mdql-core", version = "0.2.0" }
-mdql-web = { path = "../mdql-web", version = "0.2.0" }
+mdql-core = { path = "../mdql-core", version = "0.2.1" }
+mdql-web = { path = "../mdql-web", version = "0.2.1" }
 clap = { version = "4", features = ["derive"] }
 comfy-table = "7"
 serde_json = "1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "mdql"
-version = "0.2.0"
+version = "0.2.1"
 description = "MDQL — a queryable database where every entry is a markdown file"
 requires-python = ">=3.8"
 license = "AGPL-3.0-only"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -3,6 +3,7 @@ name = "mdql-python"
 version = "0.2.0"
 edition = "2021"
 publish = false
+license-file = "../LICENSE.md"
 
 [lib]
 name = "mdql"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdql-python"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 publish = false
 license-file = "../LICENSE.md"
@@ -10,7 +10,7 @@ name = "mdql"
 crate-type = ["cdylib"]
 
 [dependencies]
-mdql-core = { path = "../crates/mdql-core", version = "0.2.0" }
+mdql-core = { path = "../crates/mdql-core", version = "0.2.1" }
 pyo3 = { version = "0.23", features = ["extension-module"] }
 chrono = "0.4"
 serde_yaml = "0.9"


### PR DESCRIPTION
Fix LICENSE.md missing from Python sdist, bump to 0.2.1