### PR TITLE
v0.3.0 — MDQL_DATABASE_PATH env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,7 +1052,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mdql"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "comfy-table",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "mdql-core"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "mdql-python"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "indexmap",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "mdql-web"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "axum",
  "mdql-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 repository = "https://github.com/mdql-db/mdql"

--- a/README.md
+++ b/README.md
@@ -571,6 +571,42 @@ The web server exposes a REST API:
 - `POST /api/query` — execute SQL
 - `GET /api/fk-errors` — current foreign key violations (updated by background watcher)
 
+## Multi-agent setup
+
+MDQL is a single-writer, filesystem-based database. When multiple agents or processes need to read and write the same data, point them all at the same directory. MDQL's `flock` locking serializes writes automatically.
+
+For multi-agent setups, keep the database in its own directory (and optionally its own git repo for audit trail), separate from application code:
+
+```
+~/repos/
+  my-project/         # application code — branched freely
+  my-project-db/      # MDQL database — shared by all agents
+    _mdql.md
+    strategies/
+    orders/
+```
+
+### `MDQL_DATABASE_PATH`
+
+Set the `MDQL_DATABASE_PATH` environment variable so agents and CLI commands find the database without hardcoding paths.
+
+```bash
+export MDQL_DATABASE_PATH=~/repos/my-project-db
+
+# CLI commands fall back to this when no folder is given
+mdql validate
+mdql repl
+```
+
+```python
+from mdql import Database
+
+# Reads MDQL_DATABASE_PATH when no path is given
+db = Database()
+```
+
+An explicit path always takes precedence: `Database("/other/path")` and `mdql validate /other/path` ignore the env var.
+
 ## Pandas integration
 
 ```bash

--- a/crates/mdql-web/Cargo.toml
+++ b/crates/mdql-web/Cargo.toml
@@ -16,7 +16,7 @@ name = "mdql-web"
 path = "src/main.rs"
 
 [dependencies]
-mdql-core = { path = "../mdql-core", version = "0.2.2" }
+mdql-core = { path = "../mdql-core", version = "0.3.0" }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.6", features = ["cors"] }

--- a/crates/mdql/Cargo.toml
+++ b/crates/mdql/Cargo.toml
@@ -16,8 +16,8 @@ name = "mdql"
 path = "src/main.rs"
 
 [dependencies]
-mdql-core = { path = "../mdql-core", version = "0.2.2" }
-mdql-web = { path = "../mdql-web", version = "0.2.2" }
+mdql-core = { path = "../mdql-core", version = "0.3.0" }
+mdql-web = { path = "../mdql-web", version = "0.3.0" }
 clap = { version = "4", features = ["derive"] }
 comfy-table = "7"
 serde_json = "1"

--- a/crates/mdql/src/main.rs
+++ b/crates/mdql/src/main.rs
@@ -24,8 +24,8 @@ struct Cli {
 enum Commands {
     /// Validate all markdown files in a table folder
     Validate {
-        /// Path to table folder
-        folder: PathBuf,
+        /// Path to table or database folder (falls back to MDQL_DATABASE_PATH)
+        folder: Option<PathBuf>,
     },
     /// Run a SQL statement against a table or database
     Query {
@@ -129,6 +129,7 @@ fn is_database_dir(folder: &std::path::Path) -> bool {
 }
 
 fn discover_db(start: Option<&std::path::Path>) -> Option<PathBuf> {
+    // Walk up from start looking for _mdql.md
     let mut folder = start
         .unwrap_or(&std::env::current_dir().unwrap_or_default())
         .to_path_buf();
@@ -140,16 +141,46 @@ fn discover_db(start: Option<&std::path::Path>) -> Option<PathBuf> {
             return Some(folder);
         }
         if !folder.pop() {
-            return None;
+            break;
         }
     }
+    // Fall back to MDQL_DATABASE_PATH env var
+    if let Ok(env_path) = std::env::var("MDQL_DATABASE_PATH") {
+        let p = PathBuf::from(env_path);
+        if p.join(MDQL_FILENAME).exists() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// Resolve an optional folder argument, falling back to MDQL_DATABASE_PATH.
+fn resolve_folder(folder: Option<&std::path::Path>) -> Result<PathBuf, MdqlError> {
+    if let Some(f) = folder {
+        return Ok(f.to_path_buf());
+    }
+    if let Ok(env_path) = std::env::var("MDQL_DATABASE_PATH") {
+        let p = PathBuf::from(env_path);
+        if p.exists() {
+            return Ok(p);
+        }
+        return Err(MdqlError::General(format!(
+            "MDQL_DATABASE_PATH={} does not exist",
+            p.display()
+        )));
+    }
+    Err(MdqlError::General(
+        "No folder provided and MDQL_DATABASE_PATH not set".into(),
+    ))
 }
 
 fn main() {
     let cli = Cli::parse();
 
     let result = match cli.command {
-        Some(Commands::Validate { folder }) => cmd_validate(&folder),
+        Some(Commands::Validate { folder }) => {
+            resolve_folder(folder.as_deref()).and_then(|f| cmd_validate(&f))
+        }
         Some(Commands::Query {
             folder,
             sql,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "mdql"
-version = "0.2.2"
+version = "0.3.0"
 description = "MDQL — a queryable database where every entry is a markdown file"
 requires-python = ">=3.8"
 license = { file = "LICENSE.md" }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdql-python"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 publish = false
 license-file = "../LICENSE.md"
@@ -10,7 +10,7 @@ name = "mdql"
 crate-type = ["cdylib"]
 
 [dependencies]
-mdql-core = { path = "../crates/mdql-core", version = "0.2.2" }
+mdql-core = { path = "../crates/mdql-core", version = "0.3.0" }
 pyo3 = { version = "0.23", features = ["extension-module"] }
 chrono = "0.4"
 serde_yaml = "0.9"

--- a/python/mdql/api.py
+++ b/python/mdql/api.py
@@ -5,6 +5,7 @@ Wraps the Rust _native module to provide a Python-compatible interface.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -125,7 +126,15 @@ class Table:
 class Database:
     """A multi-table MDQL database."""
 
-    def __init__(self, path: str | Path) -> None:
+    def __init__(self, path: str | Path | None = None) -> None:
+        if path is None:
+            env_path = os.environ.get("MDQL_DATABASE_PATH")
+            if env_path:
+                path = env_path
+            else:
+                raise MdqlError(
+                    "No path provided and MDQL_DATABASE_PATH not set"
+                )
         self.path = Path(path)
         self._rust = RustDatabase(str(self.path))
 


### PR DESCRIPTION
Add MDQL_DATABASE_PATH env var fallback for Database() and CLI commands. Document multi-agent setup pattern.